### PR TITLE
set currentResponderCell

### DIFF
--- a/FXForms/Views/FXFormOptionsPickerView.m
+++ b/FXForms/Views/FXFormOptionsPickerView.m
@@ -59,6 +59,11 @@
 
 #pragma mark - Responder chain
 - (BOOL)canBecomeFirstResponder {
+    // This is necessary to set currentResponderCell in the case that the user tabs into the field rather than manually selecting it.
+    NSIndexPath *indexPathForCell = [self.field.formController indexPathForField:self.field];
+    id <FXFormFieldCell> currentCell = [self.field.formController cellForRowAtIndexPath:indexPathForCell];
+    self.field.formController.currentResponderCell = currentCell;
+    
     return YES;
 }
 

--- a/FXForms/Views/FXFormOptionsPickerView.m
+++ b/FXForms/Views/FXFormOptionsPickerView.m
@@ -50,11 +50,6 @@
         [self resignFirstResponder];
     }
     [formController deselectRowAtIndexPath:nil animated:YES];
-    
-    // Update the currentResponderCell on the formController
-    NSIndexPath *indexPathForCell = [self.field.formController indexPathForField:self.field];
-    id <FXFormFieldCell> currentCell = [self.field.formController cellForRowAtIndexPath:indexPathForCell];
-    self.field.formController.currentResponderCell = currentCell;
 }
 
 #pragma mark - Responder chain

--- a/FXForms/Views/FXFormTextFieldView.m
+++ b/FXForms/Views/FXFormTextFieldView.m
@@ -177,10 +177,6 @@
     return YES;
 }
 
-- (void)textFieldDidBeginEditing:(__unused UITextField *)textField {
-    [self.textField selectAll:nil];
-}
-
 - (void)textDidChange {
     [self updateFieldValue];
 }

--- a/FXForms/Views/FXFormTextViewView.m
+++ b/FXForms/Views/FXFormTextViewView.m
@@ -116,7 +116,6 @@
 }
 
 - (void)textViewDidBeginEditing:(__unused UITextView *)textView {
-    [self.textView selectAll:nil];
     
     // Update the currentResponderCell on the formController
     NSIndexPath *indexPathForCell = [self.field.formController indexPathForField:self.field];


### PR DESCRIPTION
The issue is documented here: https://urbnit.atlassian.net/browse/IUC-788

Was having an issue when the user was tabbing into the UIPickerCell.  This does not fire the ```- (void)didSelectWithView:(__unused UIView *)v withViewController:(__unused UIViewController *)vc withFormController:(FXFormController *)formController``` cell which screws up the flow when a user is tapping between cells.  I did notice that the canBecomeFirstResponder method fires everytime the cell is highlighted so as a hack I tried setting currentResponderCell in there and that seems to fix the issue.

Also rolled https://urbnit.atlassian.net/browse/IUC-819 into this which disables auto selection of a field text on focus.